### PR TITLE
Add Protractor Strategy

### DIFF
--- a/learn-test.gemspec
+++ b/learn-test.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "crack"
   spec.add_runtime_dependency "jasmine"
+  spec.add_runtime_dependency "colorize"
 end
 

--- a/lib/learn_test.rb
+++ b/lib/learn_test.rb
@@ -13,11 +13,13 @@ require_relative 'learn_test/runner'
 
 require_relative 'learn_test/dependency'
 require_relative 'learn_test/dependencies/phantomjs'
+require_relative 'learn_test/dependencies/protractor'
 
 require_relative 'learn_test/strategy'
 require_relative 'learn_test/strategies/jasmine'
 require_relative 'learn_test/strategies/python_unittest'
 require_relative 'learn_test/strategies/rspec'
+require_relative 'learn_test/strategies/protractor'
 
 module LearnTest
 end

--- a/lib/learn_test.rb
+++ b/lib/learn_test.rb
@@ -10,8 +10,11 @@ require_relative 'learn_test/username_parser'
 require_relative 'learn_test/repo_parser'
 require_relative 'learn_test/file_finder'
 require_relative 'learn_test/runner'
-require_relative 'learn_test/strategy'
 
+require_relative 'learn_test/dependency'
+require_relative 'learn_test/dependencies/phantomjs'
+
+require_relative 'learn_test/strategy'
 require_relative 'learn_test/strategies/jasmine'
 require_relative 'learn_test/strategies/python_unittest'
 require_relative 'learn_test/strategies/rspec'

--- a/lib/learn_test.rb
+++ b/lib/learn_test.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'faraday'
 require 'oj'
+require 'colorize'
 
 require_relative 'learn_test/version'
 require_relative 'learn_test/netrc_interactor'

--- a/lib/learn_test/dependencies/phantomjs.rb
+++ b/lib/learn_test/dependencies/phantomjs.rb
@@ -1,0 +1,55 @@
+module LearnTest
+  module Dependencies
+    class PhantomJS < LearnTest::Dependency
+      def missing?
+        if mac?
+          die('You must have Homebrew installed') unless brew_installed?
+          return !phantom_installed_on_mac?
+        end
+
+        if !phantom_installed_on_linux?
+          die("You must have PhantomJS installed: http://phantomjs.org/download.html")
+        end
+
+        super
+      end
+
+      def install
+        install_phantomjs
+      end
+
+      private
+
+      def brew_installed?
+        !`which brew`.empty?
+      end
+
+      def phantom_installed_on_mac?
+        phantom_installed_by_brew? || phantom_installed?
+      end
+
+      def phantom_installed_on_linux?
+        phantom_installed?
+      end
+      def self.check_installation
+        new.check_installation
+      end
+
+      def check_installation
+      end
+
+      def phantom_installed_by_brew?
+        !`brew ls --versions phantomjs`.empty?
+      end
+
+      def phantom_installed?
+        !`which phantomjs`.empty?
+      end
+
+      def install_phantomjs
+        print_installing('phantomjs')
+        `brew install phantomjs`
+      end
+    end
+  end
+end

--- a/lib/learn_test/dependencies/protractor.rb
+++ b/lib/learn_test/dependencies/protractor.rb
@@ -1,0 +1,16 @@
+module LearnTest
+  module Dependencies
+    class Protractor < LearnTest::Dependency
+      def missing?
+        `which protractor`.empty?
+      end
+
+      def install
+        print_installing('protractor')
+        `npm install -g protractor`
+        puts 'Updating webdriver-manager...'
+        `webdriver-manager update`
+      end
+    end
+  end
+end

--- a/lib/learn_test/dependencies/protractor.rb
+++ b/lib/learn_test/dependencies/protractor.rb
@@ -7,9 +7,21 @@ module LearnTest
 
       def install
         print_installing('protractor')
-        `npm install -g protractor`
-        puts 'Updating webdriver-manager...'
-        `webdriver-manager update`
+        run_install('npm install -g protractor')
+        puts 'Updating webdriver-manager...'.green
+        run_install('webdriver-manager update')
+      end
+
+      def run_install(command)
+        Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+          while out = stdout.gets do
+            puts out
+          end
+
+          while err = stderr.gets do
+            puts err
+          end
+        end
       end
     end
   end

--- a/lib/learn_test/dependency.rb
+++ b/lib/learn_test/dependency.rb
@@ -25,7 +25,7 @@ module LearnTest
     end
 
     def print_installing(name)
-      puts "Installing missing dependency #{name}..."
+      puts "Installing missing dependency #{name}...".green
     end
   end
 end

--- a/lib/learn_test/dependency.rb
+++ b/lib/learn_test/dependency.rb
@@ -1,0 +1,31 @@
+module LearnTest
+  class Dependency
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
+
+    def execute
+      install if missing?
+    end
+
+    def missing?
+      false
+    end
+
+    def install
+    end
+
+    def die(message)
+    end
+
+    def mac?
+      !!RUBY_PLATFORM.match(/darwin/)
+    end
+
+    def print_installing(name)
+      puts "Installing missing dependency #{name}..."
+    end
+  end
+end

--- a/lib/learn_test/runner.rb
+++ b/lib/learn_test/runner.rb
@@ -43,6 +43,7 @@ module LearnTest
       [
         LearnTest::Strategies::Rspec,
         LearnTest::Strategies::Jasmine,
+        LearnTest::Strategies::Protractor,
         LearnTest::Strategies::PythonUnittest
       ]
     end

--- a/lib/learn_test/strategies/jasmine.rb
+++ b/lib/learn_test/strategies/jasmine.rb
@@ -3,7 +3,6 @@ require 'erb'
 require 'yaml'
 require 'json'
 
-require_relative 'jasmine/phantom_checker'
 require_relative 'jasmine/initializer'
 
 module LearnTest
@@ -18,7 +17,7 @@ module LearnTest
       end
 
       def check_dependencies
-        LearnTest::Jasmine::PhantomChecker.check_installation unless options[:skip]
+        Dependencies::PhantomJS.new.execute unless options[:skip]
       end
 
       def run

--- a/lib/learn_test/strategies/protractor.rb
+++ b/lib/learn_test/strategies/protractor.rb
@@ -1,0 +1,56 @@
+require 'open3'
+require 'pry'
+
+module LearnTest
+  module Strategies
+    class Protractor < LearnTest::Strategy
+      def service_endpoint
+        '/e/protractor'
+      end
+
+      def detect
+        runner.files.include?('conf.js')
+      end
+
+      def check_dependencies
+        Dependencies::Protractor.new.execute
+      end
+
+      def run
+        Open3.popen3('protractor conf.js --resultJsonOutputFile .results.json') do |stdin, stdout, stderr, wait_thr|
+          while line = stdout.gets do
+            if line.include?('Error: Cannot find module')
+              @modules_missing = true
+            end
+            puts line
+          end
+
+          while stderr_line = stderr.gets do
+            if stderr_line.include?('ECONNREFUSED')
+              @webdriver_not_running = true
+            end
+            puts stderr_line
+          end
+
+          if wait_thr.value.exitstatus != 0
+            if @webdriver_not_running
+              die('Webdriver manager does not appear to be running. Run `webdriver-manager start` to start it.')
+            end
+
+            if @modules_missing
+              die("You appear to be missing npm dependencies. Try running `npm install`\nIf the issue persists, check the package.json")
+            end
+          end
+        end
+      end
+
+      def output
+        File.exists?('.results.json') ? Oj.load(File.read('.results.json'), symbol_keys: true) : nil
+      end
+
+      def cleanup
+        FileUtils.rm('.results.json') if File.exist?('.results.json')
+      end
+    end
+  end
+end

--- a/lib/learn_test/strategies/protractor.rb
+++ b/lib/learn_test/strategies/protractor.rb
@@ -48,6 +48,24 @@ module LearnTest
         File.exists?('.results.json') ? Oj.load(File.read('.results.json'), symbol_keys: true) : nil
       end
 
+      def results
+        @results ||= {
+          username: username,
+          github_user_id: user_id,
+          repo_name: runner.repo,
+          build: {
+            test_suite: [{
+              framework: 'protractor',
+              formatted_output: output,
+              duration: 0.0
+            }]
+          },
+          tests: 0,
+          errors: 0,
+          failures: 0
+        }
+      end
+
       def cleanup
         FileUtils.rm('.results.json') if File.exist?('.results.json')
       end

--- a/lib/learn_test/strategies/rspec.rb
+++ b/lib/learn_test/strategies/rspec.rb
@@ -57,7 +57,7 @@ module LearnTest
       end
 
       def cleanup
-        FileUtils.rm('.results.json') unless !File.exist?('.results.json')
+        FileUtils.rm('.results.json') if File.exist?('.results.json')
       end
 
       private

--- a/lib/learn_test/strategy.rb
+++ b/lib/learn_test/strategy.rb
@@ -47,5 +47,10 @@ module LearnTest
     def argv
       options[:argv]
     end
+
+    def die(message)
+      puts "\033[31m#{message}\033[0m\n"
+      exit
+    end
   end
 end

--- a/lib/learn_test/strategy.rb
+++ b/lib/learn_test/strategy.rb
@@ -49,7 +49,7 @@ module LearnTest
     end
 
     def die(message)
-      puts "\033[31m#{message}\033[0m\n"
+      puts message.red
       exit
     end
   end

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '1.2.26'
+  VERSION = '2.0.0.pre'
 end


### PR DESCRIPTION
Adds the protractor strategy. I originally tried to have it run `webdriver-manager` as well, but it added a lot of complexity to the first implementation to try managing that since I have to wait for the selenium server to boot up before running the protractor spec, so instead I detect when webdriver-manager isn't running and tell the user to start webdriver-manager themselves.

Also started extracting out dependency objects that our strategies can use to check for and install dependencies. Made one for phantomJS and protractor.

Couple remaining things:

- add nodejs dependency checker/installer
- get `output` for the protractor configured correctly from the `.results.json` file to return the correct `results` to push to learn