### PR TITLE
Move reporter requirements to the project under test for Mocha strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@
 *.so
 *.o
 *.a
+.ruby-version
 mkmf.log
+learn-test-*.gem

--- a/lib/learn_test/strategies/mocha.rb
+++ b/lib/learn_test/strategies/mocha.rb
@@ -29,7 +29,6 @@ module LearnTest
       end
 
       def run
-        install_mocha_multi
         run_mocha
       end
 
@@ -62,12 +61,29 @@ module LearnTest
       private
 
       def run_mocha
-        system("multi='json=.results.json spec=-' node_modules/mocha/bin/mocha test -R mocha-multi")
+        package = Oj.load(File.read('package.json'), symbol_keys: true)
+
+        npm_install
+
+        command = if (package[:scripts] && package[:scripts][:test] || "").include?(".results.json")
+          "npm test"
+        else
+          install_mocha_multi
+          "node_modules/.bin/mocha -R mocha-multi --reporter-options spec=-,json=.results.json"
+        end
+
+        system(command)
       end
 
       def install_mocha_multi
         if !File.exists?('node_modules/mocha-multi')
           run_install('npm install mocha-multi')
+        end
+      end
+
+      def npm_install
+        if !File.exists?('node_modules')
+          run_install('npm install')
         end
       end
     end

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '2.2.2'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
This strategy was the easiest to move, so I started here. It's coordinated with the addition of https://github.com/learn-co-curriculum/curriculum-guide-writing-tests to the Curriculum Guide (already in) and https://github.com/learn-co-curriculum/node-js-npm-lab.

The main issue that I can see is that this change will break older Mocha labs. While we're migrating those labs to conform to these new requirements, I've kept some backwards-compatibility here.