### PR TITLE
add --fail-fast option

### DIFF
--- a/bin/learn-test
+++ b/bin/learn-test
@@ -45,6 +45,10 @@ OptionParser.new do |opts|
     options[:keep] = true
   end
 
+  opts.on('--fail-fast', 'Stop running test suite on first failed test') do |f|
+    options[:fail_fast] = f
+  end
+
   if ARGV.any? { |arg| arg == "init" }
     options[:init] = true
   end

--- a/lib/learn_test/strategies/rspec.rb
+++ b/lib/learn_test/strategies/rspec.rb
@@ -21,6 +21,10 @@ module LearnTest
           argv.unshift('--format documentation')
         end
 
+        if fail_fast_option_present?
+          argv << '--fail-fast'
+        end
+
         # Don't pass the test/local flag from learn binary to rspec runner.
         argv.delete("--test")
         argv.delete("-t")
@@ -72,6 +76,10 @@ module LearnTest
 
       def format_option_present?
         options[:format]
+      end
+
+      def fail_fast_option_present?
+        options[:fail_fast]
       end
 
       def dot_rspec

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '2.3.1'
+  VERSION = '2.3.2'
 end


### PR DESCRIPTION
closes #27 
cc @loganhasson 

added support for rspec only. do we want `--fail-fast` support for any of the other test libraries?