### PR TITLE
Update non-learn directory message

### DIFF
--- a/lib/learn_test/repo_parser.rb
+++ b/lib/learn_test/repo_parser.rb
@@ -6,14 +6,14 @@ module LearnTest
       begin
         repo = Git.open(FileUtils.pwd)
       rescue
-        puts "You don't appear to be in a Learn lesson's directory. Please cd to an appropriate directory and try again."
+        puts "You don't appear to be in a Learn lesson's directory. Please enter 'learn open' or cd to an appropriate directory and try again."
         die
       end
 
       if url = repo.remote.url
         url.match(/(?:https?:\/\/|git@).*\/(.+?)(?:\.git)?$/)[1]
       else
-        puts "You don't appear to be in a Learn lesson's directory. Please cd to an appropriate directory and try again."
+        puts "You don't appear to be in a Learn lesson's directory. Please enter 'learn open' or cd to an appropriate directory and try again."
         die
       end
     end
@@ -23,4 +23,3 @@ module LearnTest
     end
   end
 end
-


### PR DESCRIPTION
Update message to instruct students to run 'learn open'  if directory is not a Learn directory (one of the more common questions from students) 