### PR TITLE
v2.5.0 - Add new Mocha and Jest strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And then execute:
 
 ## Usage
 
-From within a directory with an RSpec, Jasmine, or Python Unit Test test suite, run:
+From within a directory with an RSpec, Jasmine, Jest, Karma, Mocha, or Python Unit Test test suite, run:
 
 ```
 $ learn-test

--- a/learn-test.gemspec
+++ b/learn-test.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = LearnTest::VERSION
   spec.authors       = ["Flatiron School"]
   spec.email         = ["learn@flatironschool.com"]
-  spec.summary       = %q{Runs RSpec, Jasmine, and Python Unit Test builds and pushes JSON output to Learn.}
+  spec.summary       = %q{Runs RSpec, Jasmine, Jest, Karma, Mocha, and Python Unit Test builds and pushes JSON output to Learn.}
   spec.homepage      = "https://github.com/learn-co/learn-test"
   spec.license       = "MIT"
 
@@ -31,4 +31,3 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", "= 1.99.2"
   spec.add_runtime_dependency "selenium-webdriver", "~> 2.52.0"
 end
-

--- a/learn-test.gemspec
+++ b/learn-test.gemspec
@@ -20,14 +20,14 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "rspec", "~> 3.0"
-  spec.add_runtime_dependency "netrc"
+  spec.add_runtime_dependency "netrc", "~> 0.11.0"
   spec.add_runtime_dependency "git", "~> 1.2"
   spec.add_runtime_dependency "oj", "~> 2.9"
   spec.add_runtime_dependency "faraday", "~> 0.9"
-  spec.add_runtime_dependency "crack"
-  spec.add_runtime_dependency "jasmine"
-  spec.add_runtime_dependency "colorize"
-  spec.add_runtime_dependency "webrick", "~> 1.3.1"
+  spec.add_runtime_dependency "crack", "~> 0.4.3"
+  spec.add_runtime_dependency "jasmine", "~> 2.6.0", '>= 2.6.0'
+  spec.add_runtime_dependency "colorize", "~> 0.8.1"
+  spec.add_runtime_dependency "webrick", "~> 1.3.1", '>= 1.3.1'
   spec.add_runtime_dependency "rainbow", "= 1.99.2"
-  spec.add_runtime_dependency "selenium-webdriver", "~> 2.52.0"
+  spec.add_runtime_dependency "selenium-webdriver", "~> 2.52.0", '>= 2.52.0'
 end

--- a/lib/learn_test.rb
+++ b/lib/learn_test.rb
@@ -27,6 +27,7 @@ require_relative 'learn_test/dependencies/firefox'
 require_relative 'learn_test/dependencies/green_onion'
 
 require_relative 'learn_test/strategy'
+require_relative 'learn_test/js_strategy'
 require_relative 'learn_test/strategies/jasmine'
 require_relative 'learn_test/strategies/python_unittest'
 require_relative 'learn_test/strategies/rspec'

--- a/lib/learn_test.rb
+++ b/lib/learn_test.rb
@@ -36,6 +36,7 @@ require_relative 'learn_test/strategies/java_junit'
 require_relative 'learn_test/strategies/csharp_nunit'
 require_relative 'learn_test/strategies/mocha'
 require_relative 'learn_test/strategies/green_onion'
+require_relative 'learn_test/strategies/jest'
 
 module LearnTest
 end

--- a/lib/learn_test/js_strategy.rb
+++ b/lib/learn_test/js_strategy.rb
@@ -1,0 +1,23 @@
+module LearnTest
+  module JsStrategy
+    def js_package
+      @js_package ||= File.exist?('package.json') ? Oj.load(File.read('package.json'), symbol_keys: true) : nil
+    end
+
+    def has_js_dependency?(dep)
+      [:dependencies, :devDependencies].any? { |key| js_package[key] && js_package[key][dep] }
+    end
+
+    def missing_dependencies?
+      return true if !File.exist?("node_modules")
+
+      [:dependencies, :devDependencies, :peerDependencies].any? do |d|
+        (js_package[d] || {}).any? { |p, v| !File.exist?("node_modules/#{p}") }
+      end
+    end
+
+    def npm_install
+      run_install('npm install', npm_install: true) if missing_dependencies?
+    end
+  end
+end

--- a/lib/learn_test/runner.rb
+++ b/lib/learn_test/runner.rb
@@ -64,7 +64,8 @@ module LearnTest
         LearnTest::Strategies::Protractor,
         LearnTest::Strategies::JavaJunit,
         LearnTest::Strategies::Mocha,
-        LearnTest::Strategies::PythonUnittest
+        LearnTest::Strategies::PythonUnittest,
+        LearnTest::Strategies::Jest
       ]
     end
 

--- a/lib/learn_test/strategies/jest.rb
+++ b/lib/learn_test/strategies/jest.rb
@@ -1,6 +1,8 @@
 module LearnTest
   module Strategies
     class Jest < LearnTest::Strategy
+      include LearnTest::JsStrategy
+
       def service_endpoint
         '/e/flatiron_jest'
       end
@@ -49,7 +51,7 @@ module LearnTest
       private
 
       def run_jest
-        npm_install(js_package)
+        npm_install
 
         system('npm test')
       end

--- a/lib/learn_test/strategies/jest.rb
+++ b/lib/learn_test/strategies/jest.rb
@@ -1,0 +1,91 @@
+module LearnTest
+  module Strategies
+    class Jest < LearnTest::Strategy
+      def service_endpoint
+        '/e/flatiron_jest'
+      end
+
+      def detect
+        package = File.exists?('package.json') ? Oj.load(File.read('package.json'), symbol_keys: true) : nil
+        return false if !package
+
+        if package[:scripts] && package[:scripts][:test]
+          return true if package[:scripts][:test].include?('jest')
+        end
+
+        if package[:devDependencies] && package[:devDependencies][:jest]
+          return true if (package[:devDependencies][:jest].length > 0)
+        end
+
+        if package[:dependencies] && package[:dependencies][:jest]
+          return true if (package[:dependencies][:jest].length > 0)
+        end
+
+        return false
+      end
+
+      def check_dependencies
+        Dependencies::NodeJS.new.execute
+      end
+
+      def run
+        run_jest
+      end
+
+      def output
+        @output ||= File.exists?('.results.json') ? Oj.load(File.read('.results.json'), symbol_keys: true) : nil
+      end
+
+      def results
+        @results ||= {
+          username: username,
+          github_user_id: user_id,
+          learn_oauth_token: learn_oauth_token,
+          repo_name: runner.repo,
+          build: {
+            test_suite: [{
+              framework: 'jest',
+              formatted_output: output,
+              duration: duration
+            }]
+          },
+          examples: output[:numTotalTests],
+          passing_count: output[:numPassedTests],
+          failure_count: output[:numFailedTests]
+        }
+      end
+
+      def cleanup
+        FileUtils.rm('.results.json') if File.exist?('.results.json')
+      end
+
+      def missing_dependencies?(package)
+        return true if !File.exists?("node_modules")
+
+        [:dependencies, :devDependencies, :peerDependencies].any? do |d|
+          (package[d] || {}).any? { |p, v| !File.exists?("node_modules/#{p}") }
+        end
+      end
+
+      private
+
+      def run_jest
+        package = Oj.load(File.read('package.json'), symbol_keys: true)
+
+        npm_install(package)
+
+        command = 'npm test'
+
+        system(command)
+      end
+
+      def npm_install(package)
+        run_install('npm install', npm_install: true) if missing_dependencies?(package)
+      end
+
+      def duration
+        output[:testResults][0][:endTime] - output[:testResults][0][:startTime]
+      end
+    end
+  end
+end

--- a/lib/learn_test/strategies/jest.rb
+++ b/lib/learn_test/strategies/jest.rb
@@ -6,22 +6,9 @@ module LearnTest
       end
 
       def detect
-        package = File.exists?('package.json') ? Oj.load(File.read('package.json'), symbol_keys: true) : nil
-        return false if !package
+        return false if !js_package
 
-        if package[:scripts] && package[:scripts][:test]
-          return true if package[:scripts][:test].include?('jest')
-        end
-
-        if package[:devDependencies] && package[:devDependencies][:jest]
-          return true if (package[:devDependencies][:jest].length > 0)
-        end
-
-        if package[:dependencies] && package[:dependencies][:jest]
-          return true if (package[:dependencies][:jest].length > 0)
-        end
-
-        return false
+        has_js_dependency?(:jest) ? true : false
       end
 
       def check_dependencies
@@ -59,28 +46,12 @@ module LearnTest
         FileUtils.rm('.results.json') if File.exist?('.results.json')
       end
 
-      def missing_dependencies?(package)
-        return true if !File.exists?("node_modules")
-
-        [:dependencies, :devDependencies, :peerDependencies].any? do |d|
-          (package[d] || {}).any? { |p, v| !File.exists?("node_modules/#{p}") }
-        end
-      end
-
       private
 
       def run_jest
-        package = Oj.load(File.read('package.json'), symbol_keys: true)
+        npm_install(js_package)
 
-        npm_install(package)
-
-        command = 'npm test'
-
-        system(command)
-      end
-
-      def npm_install(package)
-        run_install('npm install', npm_install: true) if missing_dependencies?(package)
+        system('npm test')
       end
 
       def duration

--- a/lib/learn_test/strategies/mocha.rb
+++ b/lib/learn_test/strategies/mocha.rb
@@ -1,6 +1,8 @@
 module LearnTest
   module Strategies
     class Mocha < LearnTest::Strategy
+      attr_accessor :mocha_in_browser
+
       def service_endpoint
         '/e/flatiron_mocha'
       end
@@ -9,16 +11,34 @@ module LearnTest
         package = File.exist?('package.json') ? Oj.load(File.read('package.json'), symbol_keys: true) : nil
         return false if !package
 
-        if package[:scripts] && package[:scripts][:test]
-          return true if package[:scripts][:test].include? 'mocha'
+        if package[:scripts] && package[:scripts][:test] && package[:scripts][:test].include?('mocha')
+          self.mocha_in_browser = false
+
+          return true
         end
 
-        if package[:devDependencies] && package[:devDependencies][:mocha]
-          return true if (package[:devDependencies][:mocha].length > 0)
+        if package[:devDependencies]
+          if package[:devDependencies][:mocha]
+            self.mocha_in_browser = false
+
+            return true
+          elsif package[:devDependencies][:'learn-browser']
+            self.mocha_in_browser = true
+
+            return true
+          end
         end
 
-        if package[:dependencies] && package[:dependencies][:mocha]
-          return true if (package[:dependencies][:mocha].length > 0)
+        if package[:dependencies]
+          if package[:dependencies][:mocha]
+            self.mocha_in_browser = false
+
+            return true
+          elsif package[:dependencies][:'learn-browser']
+            self.mocha_in_browser = true
+
+            return true
+          end
         end
 
         return false
@@ -33,11 +53,38 @@ module LearnTest
       end
 
       def cleanup
-        FileUtils.rm('learn.auth.data.json') if File.exist?('learn.auth.data.json')
+        if mocha_in_browser
+          FileUtils.rm('learn.auth.data.json') if File.exist?('learn.auth.data.json')
+        else
+          FileUtils.rm('.results.json') if File.exist?('.results.json')
+        end
       end
 
       def push_results?
-        false
+        !mocha_in_browser
+      end
+
+      def results
+        @results ||= {
+          username: username,
+          github_user_id: user_id,
+          learn_oauth_token: learn_oauth_token,
+          repo_name: runner.repo,
+          build: {
+            test_suite: [{
+              framework: 'mocha',
+              formatted_output: output,
+              duration: output[:stats]
+            }]
+          },
+          examples: output[:stats][:tests],
+          passing_count: output[:stats][:passes],
+          failure_count: output[:stats][:failures]
+        }
+      end
+
+      def output
+        @output ||= File.exists?('.results.json') ? Oj.load(File.read('.results.json'), symbol_keys: true) : nil
       end
 
       private
@@ -47,22 +94,41 @@ module LearnTest
 
         npm_install(package)
 
+        if mocha_in_browser
+          run_browser_based_mocha
+        else
+          run_node_based_mocha(package)
+        end
+      end
+
+      def run_browser_based_mocha
         write_auth_data_to_file
 
-        puts "Navigate to #{testing_address} in your browser to run the test suite."
+        puts "Navigate to ".red + testing_address.blue + " in your browser to run the test suite.".red
         puts "As you write code in index.js, save your work often. With each save, the browser"
         puts "will automatically refresh and rerun the test suite against your updated code."
-        puts "To exit, press CTRL-C in the terminal."
+        puts "To exit the test suite and return to your terminal, press CTRL-C.".red
 
         begin
-          system("browser-sync start --config bs-config.js")
+          system("browser-sync start --config node_modules/learn-browser/bs-config.js")
         rescue Interrupt
-          puts "\nExiting test suite..."
+          puts "\nExiting test suite...".red
 
           cleanup
 
           exit
         end
+      end
+
+      def run_node_based_mocha(package)
+        command = if (package[:scripts] && package[:scripts][:test] || "").include?(".results.json")
+          "npm test"
+        else
+          install_mocha_multi
+          "node_modules/.bin/mocha -R mocha-multi --reporter-options spec=-,json=.results.json"
+        end
+
+        system(command)
       end
 
       def missing_dependencies?(package)
@@ -100,6 +166,12 @@ module LearnTest
 
       def testing_address
         in_IDE? ? "http://#{ENV['HOST_IP']}:#{ENV['PORT']}/" : "http://localhost:8000/"
+      end
+
+      def install_mocha_multi
+        if !File.exists?('node_modules/mocha-multi')
+          run_install('npm install mocha-multi', npm_install: true)
+        end
       end
     end
   end

--- a/lib/learn_test/strategies/mocha.rb
+++ b/lib/learn_test/strategies/mocha.rb
@@ -110,7 +110,13 @@ module LearnTest
         puts "To exit the test suite and return to your terminal, press CTRL-C.".red
 
         begin
-          system("browser-sync start --config node_modules/learn-browser/bs-config.js")
+          command = if browser_sync_executable?
+            "browser-sync start --config node_modules/learn-browser/bs-config.js"
+          else
+            "node_modules/browser-sync/bin/browser-sync.js start --config node_modules/learn-browser/bs-config.js"
+          end
+
+          system(command)
         rescue Interrupt
           puts "\nExiting test suite...".red
 
@@ -162,6 +168,10 @@ module LearnTest
 
       def in_IDE?
         ENV['IDE_CONTAINER'] == 'true'
+      end
+
+      def browser_sync_executable?
+        system("which browser-sync > /dev/null 2>&1")
       end
 
       def testing_address

--- a/lib/learn_test/strategies/mocha.rb
+++ b/lib/learn_test/strategies/mocha.rb
@@ -1,6 +1,8 @@
 module LearnTest
   module Strategies
     class Mocha < LearnTest::Strategy
+      include LearnTest::JsStrategy
+
       def service_endpoint
         '/e/flatiron_mocha'
       end
@@ -57,12 +59,12 @@ module LearnTest
       private
 
       def run_mocha
-        npm_install(js_package)
+        npm_install
 
         if in_browser?
           run_browser_based_mocha
         else
-          run_node_based_mocha(js_package)
+          run_node_based_mocha
         end
       end
 

--- a/lib/learn_test/strategy.rb
+++ b/lib/learn_test/strategy.rb
@@ -79,25 +79,5 @@ module LearnTest
         end
       end
     end
-
-    def js_package
-      @package ||= File.exist?('package.json') ? Oj.load(File.read('package.json'), symbol_keys: true) : nil
-    end
-
-    def has_js_dependency?(dep)
-      [:dependencies, :devDependencies].any? { |key| package_json[key] && package_json[key][dep] }
-    end
-
-    def missing_dependencies?
-      return true if !File.exist?("node_modules")
-
-      [:dependencies, :devDependencies, :peerDependencies].any? do |d|
-        (js_package[d] || {}).any? { |p, v| !File.exist?("node_modules/#{p}") }
-      end
-    end
-
-    def npm_install
-      run_install('npm install', npm_install: true) if missing_dependencies?(js_package)
-    end
   end
 end

--- a/lib/learn_test/strategy.rb
+++ b/lib/learn_test/strategy.rb
@@ -79,5 +79,25 @@ module LearnTest
         end
       end
     end
+
+    def js_package
+      @package ||= File.exist?('package.json') ? Oj.load(File.read('package.json'), symbol_keys: true) : nil
+    end
+
+    def has_js_dependency?(dep)
+      [:dependencies, :devDependencies].any? { |key| package_json[key] && package_json[key][dep] }
+    end
+
+    def missing_dependencies?
+      return true if !File.exist?("node_modules")
+
+      [:dependencies, :devDependencies, :peerDependencies].any? do |d|
+        (js_package[d] || {}).any? { |p, v| !File.exist?("node_modules/#{p}") }
+      end
+    end
+
+    def npm_install
+      run_install('npm install', npm_install: true) if missing_dependencies?(js_package)
+    end
   end
 end

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '2.4.3'
+  VERSION = '2.5.0'
 end

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '2.4.2'
+  VERSION = '2.4.3'
 end

--- a/spec/lib/learn_test/strategies/jest_spec.rb
+++ b/spec/lib/learn_test/strategies/jest_spec.rb
@@ -1,0 +1,60 @@
+describe LearnTest::Strategies::Jest do
+  describe '#missing_dependencies?' do
+    let(:package) do
+      {
+        dependencies: {
+          dep1: "",
+          dep2: ""
+        },
+        devDependencies: {
+          devDep1: "",
+          devDep2: ""
+        },
+        peerDependencies: {
+          peerDep1: "",
+          peerDep2: ""
+        }
+      }
+    end
+    let(:runner) { double("Runner", options: {}) }
+    let(:strategy) { LearnTest::Strategies::Jest.new(runner) }
+
+    it "returns true if no node_modules directory" do
+      expect(File).to receive(:exists?).with("node_modules") { false }
+
+      expect(strategy.missing_dependencies?(package)).to eq(true)
+    end
+
+    context "node_modules exists" do
+      before(:each) do
+        allow(File).to receive(:exists?) { true }
+      end
+
+      it "returns true if missing a dependency" do
+        expect(File).to receive(:exists?).with("node_modules/dep1") { true }
+        expect(File).to receive(:exists?).with("node_modules/dep2") { false }
+        expect(strategy.missing_dependencies?(package)).to eq(true)
+      end
+
+      it "returns true if missing a devDependency" do
+        expect(File).to receive(:exists?).with("node_modules/devDep1") { true }
+        expect(File).to receive(:exists?).with("node_modules/devDep2") { false }
+        expect(strategy.missing_dependencies?(package)).to eq(true)
+      end
+
+      it "returns true if missing a peerDependency" do
+        expect(File).to receive(:exists?).with("node_modules/peerDep1") { true }
+        expect(File).to receive(:exists?).with("node_modules/peerDep2") { false }
+        expect(strategy.missing_dependencies?(package)).to eq(true)
+      end
+
+      it "returns false if missing no dependencies" do
+        expect(strategy.missing_dependencies?(package)).to eq(false)
+      end
+
+      it "returns false if there are no dependencies" do
+        expect(strategy.missing_dependencies?({})).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@adamjonas — bumped it to 2.4.3 instead of 2.5.0 and added back that file-ending new line. Someone with push access will have to `rake build` and `rake release`.