### PR TITLE
Fix installation issues due to broken jasmine-core release

### DIFF
--- a/learn-test.gemspec
+++ b/learn-test.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "oj", "~> 2.9"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "crack", "~> 0.4.3"
-  spec.add_runtime_dependency "jasmine", "~> 2.6.0", '>= 2.6.0'
+  spec.add_runtime_dependency "jasmine", "~> 2.6.0", ">= 2.6.0"
+  spec.add_runtime_dependency "jasmine-core", "< 2.99.1"
   spec.add_runtime_dependency "colorize", "~> 0.8.1"
-  spec.add_runtime_dependency "webrick", "~> 1.3.1", '>= 1.3.1'
+  spec.add_runtime_dependency "webrick", "~> 1.3.1", ">= 1.3.1"
   spec.add_runtime_dependency "rainbow", "= 1.99.2"
   spec.add_runtime_dependency "selenium-webdriver", "~> 2.52.0", '>= 2.52.0'
 end


### PR DESCRIPTION
Restrict jasmine-core version number to exclude broken release.

There appears to be a symlink issue when installing, issue is reported at https://github.com/jasmine/jasmine/issues/1502.

```
$ gem install learn-co -v '3.8.5' --no-ri --no-rdoc
Successfully installed rspec-3.7.0
Successfully installed netrc-0.11.0
Successfully installed git-1.3.0
Building native extensions.  This could take a while...
ERROR:  While executing gem ... (Errno::EEXIST)
    File exists @ dir_s_mkdir - /usr/local/rvm/gems/ruby-2.3.1/gems/jasmine-core-2.99.1/lib/jasmine-core/spec
Successfully installed oj-2.18.5
Successfully installed multipart-post-2.0.0
Successfully installed faraday-0.14.0
Successfully installed crack-0.4.3
The command 'gem install learn-co -v '3.8.5' --no-ri --no-rdoc' returned a non-zero code: 1
```