### PR TITLE
More flexible python test detection

### DIFF
--- a/lib/learn_test/strategies/python_unittest.rb
+++ b/lib/learn_test/strategies/python_unittest.rb
@@ -9,7 +9,7 @@ module LearnTest
       end
 
       def detect
-        runner.files.any? {|f| f.match(/.*.py$/) }
+        test_files.any? {|f| f.match(/.*\.py$/) }
       end
 
       def check_dependencies
@@ -23,6 +23,10 @@ module LearnTest
 
       def output
         @output ||= Oj.load(File.read('.results.json'), symbol_keys: true)
+      end
+
+      def test_files
+        @test_files ||= Dir.glob("**/*_test.py")
       end
 
       def results

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '2.5.3'
+  VERSION = '2.5.4'
 end


### PR DESCRIPTION
This change allows us to detect that we should use the `PythonUnittestStrategy` when there are test files in the `test` directory rather than in the top-level directory of a lab. See [docs](http://nose.readthedocs.io/en/latest/finding_tests.html) for more information on how nose finds tests.

All labs containing PythonUnittest should follow this pattern going forward, as this also confirms to how we classify labs and readmes on Learn.