### PR TITLE
move ironbroker URL to an env var to make it easier to test

### DIFF
--- a/lib/learn_test/client.rb
+++ b/lib/learn_test/client.rb
@@ -3,7 +3,7 @@ require 'json'
 
 module LearnTest
   class Client
-    SERVICE_URL = 'http://ironbroker-v2.flatironschool.com'.freeze
+    SERVICE_URL = ENV.fetch('IRONBROKER_URL', 'http://ironbroker-v2.flatironschool.com').freeze
 
     def initialize(service_url = SERVICE_URL)
       @conn = Faraday.new(url: service_url) do |faraday|

--- a/lib/learn_test/version.rb
+++ b/lib/learn_test/version.rb
@@ -1,3 +1,3 @@
 module LearnTest
-  VERSION = '2.5.5'
+  VERSION = '2.5.6'
 end


### PR DESCRIPTION
Now if you need to hit QA or local, rather than editing the gem, you can just do `export IRONBROKER_URL=http://qa-ironbroker04.fe.flatironschool.com` and run the tests