### PR TITLE
prototype option to run rspec with ruby warnings enabled

### DIFF
--- a/bin/learn-test
+++ b/bin/learn-test
@@ -61,6 +61,10 @@ OptionParser.new do |opts|
     (options[:example] ||= []) << s
   end
 
+  opts.on("-w", "--run-rspec-with-ruby-warnings-on", "Runs RSpec with Ruby warnings enabled ('-w')") do |w|
+    options[:ruby_warnings] = w
+  end
+
   if ARGV.any? { |arg| arg == "init" }
     options[:init] = true
   end

--- a/lib/learn_test/strategies/rspec.rb
+++ b/lib/learn_test/strategies/rspec.rb
@@ -25,6 +25,10 @@ module LearnTest
           argv << '--fail-fast'
         end
 
+        if warning_option_present?
+          argv << '-w'
+        end
+
         if example_option_present?
           argv << options[:example].map{|e| "--example #{e}"}.join(" ")
         end
@@ -89,6 +93,10 @@ module LearnTest
 
       def example_option_present?
         options[:example]
+      end
+
+      def warning_option_present?
+        options[:ruby_warnings]
       end
 
       def dot_rspec


### PR DESCRIPTION
I've added the option to run RSpec with Ruby warnings enabled. Personally, I'd love to see this enabled by default - I've found sketchy things in some of the specs for the labs I've been working on - but in the meantime, this does what I need it to do, and shouldn't be too controversial.

What do the maintainers think about running RSpec with warnings enabled by default?