### PR TITLE
Fix ~/.netrc issue; Add specs for LearnTest::UsernameParser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,22 @@ jobs:
           key: gems-v1-{{ checksum "Gemfile.lock" }}
 
       - run:
-          name: Install Dependencies
+          name: Force Bundler Version
           command: |
-            bundle config path ".bundle"
-            bundle install
+            sudo gem update --system
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
+
+      - run:
+          name: Install Dependencies
+          command: bundle install
 
       - save_cache:
           key: gems-v1-{{ checksum "Gemfile.lock" }}
           paths:
+            - /usr/local/bin/gem
+            - /usr/local/bin/bundle
             - .bundle
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ jobs:
 
       - run:
           name: Create ~/.netrc
-          command: cp spec/fixtures/.netrc ~/
+          command: | 
+            cp spec/fixtures/.netrc ~/
+            chmod 0600 ~/.netrc
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
             sudo gem update --system
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler
 
       - run:
           name: Install Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            bundle config set --local 'vendor/bundle'
+            bundle config --local set vendor/bundle
             bundle install
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
        - image: circleci/ruby:2.4.1-node-browsers
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
 
@@ -25,8 +19,11 @@ jobs:
             gem install bundler
             bundle config set path 'vendor/bundle'
             bundle install --jobs=4 --retry=3
-        
-      # run tests!
+
+      - run:
+          name: create ~/.netrc
+          command: cp spec/fixtures/.netrc ~/
+
       - run:
           name: run tests
           command: |
@@ -42,6 +39,7 @@ jobs:
       # collect reports
       - store_test_results:
           path: /tmp/test-results
+
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle update --bundler
+            gem install bundler
             bundle config set path 'vendor/bundle'
             bundle install --jobs=4 --retry=3
         

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,30 +2,38 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.4.1-node-browsers
+       - image: circleci/ruby:2.5.8
 
     working_directory: ~/repo
 
     steps:
       - checkout
 
-      - run:
-          name: install dependencies
-          command: |
-            gem install bundler
-            bundle config set --local path 'vendor/bundle'
-            bundle install --jobs=4 --retry=3
+      - restore_cache:
+          key: gems-v1-{{ checksum "Gemfile.lock" }}
 
       - run:
-          name: create ~/.netrc
+          name: Install Dependencies
+          command: |
+            bundle config path ".bundle"
+            bundle install
+
+      - save_cache:
+          key: gems-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - .bundle
+
+      - run:
+          name: Create ~/.netrc
           command: cp spec/fixtures/.netrc ~/
 
       - run:
-          name: run tests
+          name: Run tests
           command: |
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
@@ -36,7 +44,6 @@ jobs:
                             --format progress \
                             $TEST_FILES
 
-      # collect reports
       - store_test_results:
           path: /tmp/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            gem install bundler
+            bundle update --bundler
             bundle config set path 'vendor/bundle'
             bundle install --jobs=4 --retry=3
         

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,3 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
 version: 2.1
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - gems-v2-{{ checksum "Gemfile.lock" }}
-            - gems-v2-
+            - gems-v3-{{ checksum "Gemfile.lock" }}
+            - gems-v3-
 
       - run:
           name: Force Bundler Version
@@ -29,7 +29,7 @@ jobs:
             bundle install
 
       - save_cache:
-          key: gems-v2-{{ checksum "Gemfile.lock" }}
+          key: gems-v3-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: gems-v1-{{ checksum "Gemfile.lock" }}
+          keys:
+            - gems-v2-{{ checksum "Gemfile.lock" }}
+            - gems-v2-
 
       - run:
           name: Force Bundler Version
@@ -27,14 +29,14 @@ jobs:
 
       - run:
           name: Install Dependencies
-          command: bundle install
+          command: |
+            bundle config set --local 'vendor/bundle'
+            bundle install
 
       - save_cache:
-          key: gems-v1-{{ checksum "Gemfile.lock" }}
+          key: gems-v2-{{ checksum "Gemfile.lock" }}
           paths:
-            - /usr/local/bin/gem
-            - /usr/local/bin/bundle
-            - .bundle
+            - vendor/bundle
 
       - run:
           name: Create ~/.netrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: install dependencies
           command: |
             gem install bundler
-            bundle config set path 'vendor/bundle'
+            bundle config set --local path 'vendor/bundle'
             bundle install --jobs=4 --retry=3
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ jobs:
           name: install dependencies
           command: |
             gem install bundler
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle config set path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
         
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            gem install bundler
             bundle install --jobs=4 --retry=3 --path vendor/bundle
         
       # run tests!

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in learn.gemspec
 gemspec
+
+group :test do
+  gem 'rspec_junit_formatter', '~> 0.4.1'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,83 @@
+PATH
+  remote: .
+  specs:
+    learn-test (2.6.1)
+      colorize (~> 0.8.1)
+      crack (~> 0.4.3)
+      faraday (~> 0.9)
+      git (~> 1.2)
+      jasmine (~> 2.6.0, >= 2.6.0)
+      jasmine-core (< 2.99.1)
+      netrc (~> 0.11.0)
+      oj (~> 2.9)
+      rainbow (= 1.99.2)
+      rspec (~> 3.0)
+      selenium-webdriver (~> 2.52.0, >= 2.52.0)
+      webrick (~> 1.3.1, >= 1.3.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    colorize (0.8.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.4.4)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.13.1)
+    git (1.7.0)
+      rchardet (~> 1.8)
+    jasmine (2.6.0)
+      jasmine-core (>= 2.6.0, < 3.0.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.99.0)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
+    netrc (0.11.0)
+    oj (2.18.5)
+    phantomjs (2.1.1.0)
+    rack (2.2.3)
+    rainbow (1.99.2)
+    rake (10.5.0)
+    rchardet (1.8.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    rubyzip (1.3.0)
+    safe_yaml (1.0.5)
+    selenium-webdriver (2.52.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
+    webrick (1.3.1)
+    websocket (1.2.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.0)
+  learn-test!
+  rake (~> 10.0)
+  rspec (~> 3.8)
+  rspec_junit_formatter (~> 0.4.1)
+
+BUNDLED WITH
+   2.1.4

--- a/learn-test.gemspec
+++ b/learn-test.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib", "bin"]
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.8"
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"
   spec.add_runtime_dependency "rspec", "~> 3.0"
   spec.add_runtime_dependency "netrc", "~> 0.11.0"
   spec.add_runtime_dependency "git", "~> 1.2"

--- a/learn-test.gemspec
+++ b/learn-test.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"
   spec.add_runtime_dependency "rspec", "~> 3.0"
   spec.add_runtime_dependency "netrc", "~> 0.11.0"
   spec.add_runtime_dependency "git", "~> 1.2"

--- a/lib/learn_test/username_parser.rb
+++ b/lib/learn_test/username_parser.rb
@@ -7,7 +7,7 @@ module LearnTest
 
       if !LearnTest::LearnOauthTokenParser.get_learn_oauth_token && (!username || user_id == 'none')
         print "Enter your github username: "
-        username = gets.strip
+        username = $stdin.gets.strip
         user_id = LearnTest::GithubInteractor.get_user_id_for(username)
         parser.write(username, user_id)
       end

--- a/spec/features/rspec_unit_spec.rb
+++ b/spec/features/rspec_unit_spec.rb
@@ -1,8 +1,14 @@
 describe "Running a RSpec Unit Test" do
+  before(:all) do
+    # While it doesn't cause these tests to fail, nasty messages occur, and more,
+    # occur when either a ~/.netrc entry or file exists. This aims to correct that,
+    # and will only ever be called once.
+
+    LearnTest::UsernameParser.get_username
+  end
+
   context 'a basic rspec unit test' do
     it 'runs the spec with 0 failures' do
-      allow($stdin).to receive(:gets).and_return('learn-co')
-
       output = `cd ./spec/fixtures/rspec-unit-spec && ./../../../bin/learn-test --local --test`
 
       expect(output).to include('3 examples, 0 failures')
@@ -12,8 +18,6 @@ describe "Running a RSpec Unit Test" do
 
   context 'with the --example flag' do
     it 'runs only the appropriate tests' do
-      allow($stdin).to receive(:gets).and_return('learn-co')
-
       output = `cd ./spec/fixtures/rspec-unit-spec && ./../../../bin/learn-test --local --test --example multiple`
 
       expect(output).to include('1 example, 0 failures')
@@ -21,8 +25,6 @@ describe "Running a RSpec Unit Test" do
     end
 
      it 'accepts multiple examples' do
-      allow($stdin).to receive(:gets).and_return('learn-co')
-
       output = `cd ./spec/fixtures/rspec-unit-spec && ./../../../bin/learn-test --local --test --example multiple --example accepts`
 
       expect(output).to include('2 examples, 0 failures')

--- a/spec/features/rspec_unit_spec.rb
+++ b/spec/features/rspec_unit_spec.rb
@@ -1,7 +1,7 @@
 describe "Running a RSpec Unit Test" do
   before(:all) do
     # While it doesn't cause these tests to fail, nasty messages occur, and more,
-    # occur when either a ~/.netrc entry or file exists. This aims to correct that,
+    # when either a ~/.netrc entry or file exists. This aims to correct that,
     # and will only ever be called once.
 
     LearnTest::UsernameParser.get_username

--- a/spec/features/rspec_unit_spec.rb
+++ b/spec/features/rspec_unit_spec.rb
@@ -1,7 +1,7 @@
 describe "Running a RSpec Unit Test" do
   before(:all) do
-    # While it doesn't cause these tests to fail, nasty messages occur, and more,
-    # when either a ~/.netrc entry or file exists. This aims to correct that,
+    # While it doesn't cause these tests to fail, nasty messages occur (and more)
+    # when either a ~/.netrc entry or file itself doesn't exist. This aims to correct that,
     # and will only ever be called once.
 
     LearnTest::UsernameParser.get_username

--- a/spec/features/rspec_unit_spec.rb
+++ b/spec/features/rspec_unit_spec.rb
@@ -1,6 +1,8 @@
 describe "Running a RSpec Unit Test" do
   context 'a basic rspec unit test' do
     it 'runs the spec with 0 failures' do
+      allow($stdin).to receive(:gets).and_return('learn-co')
+
       output = `cd ./spec/fixtures/rspec-unit-spec && ./../../../bin/learn-test --local --test`
 
       expect(output).to include('3 examples, 0 failures')
@@ -10,6 +12,8 @@ describe "Running a RSpec Unit Test" do
 
   context 'with the --example flag' do
     it 'runs only the appropriate tests' do
+      allow($stdin).to receive(:gets).and_return('learn-co')
+
       output = `cd ./spec/fixtures/rspec-unit-spec && ./../../../bin/learn-test --local --test --example multiple`
 
       expect(output).to include('1 example, 0 failures')
@@ -17,6 +21,8 @@ describe "Running a RSpec Unit Test" do
     end
 
      it 'accepts multiple examples' do
+      allow($stdin).to receive(:gets).and_return('learn-co')
+
       output = `cd ./spec/fixtures/rspec-unit-spec && ./../../../bin/learn-test --local --test --example multiple --example accepts`
 
       expect(output).to include('2 examples, 0 failures')

--- a/spec/fixtures/.netrc
+++ b/spec/fixtures/.netrc
@@ -1,0 +1,3 @@
+machine flatiron-push
+  login tmilewski
+  password 26691

--- a/spec/learn_test/username_parser_spec.rb
+++ b/spec/learn_test/username_parser_spec.rb
@@ -1,0 +1,61 @@
+describe LearnTest::UsernameParser do
+  subject { LearnTest::UsernameParser }
+
+  let(:dbl) { instance_double(LearnTest::NetrcInteractor) }
+
+  let!(:username) { 'learn-co' }
+  let!(:user_id) { '12345' }
+  let!(:token) { 'abc123' }
+
+  context 'user details are stored in ~/.netrc' do
+    context 'username/password' do
+      it 'should return a username' do
+        expect(LearnTest::LearnOauthTokenParser).to receive(:get_learn_oauth_token).and_return(token)
+
+        expect(LearnTest::NetrcInteractor).to receive(:new).and_return(dbl)
+        expect(dbl).to receive(:username).and_return(username)
+        expect(dbl).to receive(:user_id).and_return(user_id)
+
+        expect(dbl).to_not receive(:write)
+
+        expect(subject.get_username).to eq(username)
+      end
+    end
+
+    context 'oauth token' do
+      it 'should return a username' do
+        expect(LearnTest::LearnOauthTokenParser).to receive(:get_learn_oauth_token).and_return(token)
+
+        expect(LearnTest::NetrcInteractor).to receive(:new).and_return(dbl)
+        expect(dbl).to receive(:username).and_return(nil)
+        expect(dbl).to receive(:user_id).and_return(nil)
+
+        expect(dbl).to_not receive(:write)
+
+        expect(subject.get_username).to eq(nil)
+      end
+    end
+  end
+
+  context 'user details are not stored in ~/.netrc' do
+    it 'should ask for and store a username' do
+      @original_stdout = $stdout
+      $stdout = File.open(File::NULL, 'w')
+
+      expect(LearnTest::LearnOauthTokenParser).to receive(:get_learn_oauth_token).and_return(nil)
+
+      expect(LearnTest::NetrcInteractor).to receive(:new).and_return(dbl)
+      expect(dbl).to receive(:username).and_return(nil)
+      expect(dbl).to receive(:user_id).and_return(nil)
+
+      expect($stdin).to receive(:gets).and_return(username)
+      expect(LearnTest::GithubInteractor).to receive(:get_user_id_for).with(username).and_return(user_id)
+      expect(dbl).to receive(:write).with(username, user_id)
+
+      expect(subject.get_username).to eq(username)
+
+      $stdout = @original_stdout
+      @original_stdout = nil
+    end
+  end
+end


### PR DESCRIPTION
A testing edge case occurs when no ~/.netrc file exists, or it doesn't have a FIS entry. This PR aims to correct that.

And, I added some testing.

![nothing but net](https://media.giphy.com/media/3o7WTDojbnKG6nY4Q8/giphy.gif)