### PR TITLE
[EDM-1519] Add "none", or null, strategy for Canvas code-alongs

### DIFF
--- a/lib/learn_test.rb
+++ b/lib/learn_test.rb
@@ -26,6 +26,7 @@ require_relative 'learn_test/strategies/java_junit'
 require_relative 'learn_test/strategies/csharp_nunit'
 require_relative 'learn_test/strategies/mocha'
 require_relative 'learn_test/strategies/pytest'
+require_relative 'learn_test/strategies/none'
 
 module LearnTest
   module Dependencies

--- a/lib/learn_test/runner.rb
+++ b/lib/learn_test/runner.rb
@@ -57,7 +57,8 @@ module LearnTest
         LearnTest::Strategies::Protractor,
         LearnTest::Strategies::JavaJunit,
         LearnTest::Strategies::Mocha,
-        LearnTest::Strategies::Pytest
+        LearnTest::Strategies::Pytest,
+        LearnTest::Strategies::None
       ]
     end
 

--- a/lib/learn_test/strategies/none.rb
+++ b/lib/learn_test/strategies/none.rb
@@ -12,7 +12,7 @@ module LearnTest
       end
 
       def run
-        puts "This directory doesn't appear to have any specs but a submission will be made."
+        puts 'Your assignment was submitted. You can resubmit by running `learn test` again.'
       end
 
       def results

--- a/lib/learn_test/strategies/none.rb
+++ b/lib/learn_test/strategies/none.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module LearnTest
+  module Strategies
+    class None < LearnTest::Strategy
+      def service_endpoint
+        '/e/flatiron_none'
+      end
+
+      def detect
+        runner.files.include?('.canvas')
+      end
+
+      def run
+        puts "This directory doesn't appear to have any specs but a submission will be made."
+      end
+
+      def results
+        {
+          username: username,
+          github_user_id: user_id,
+          learn_oauth_token: learn_oauth_token,
+          repo_name: runner.repo,
+          build: {
+            test_suite: [{
+              framework: 'none',
+              formatted_output: '',
+              duration: nil
+            }]
+          },
+          examples: 0,
+          passing_count: 0,
+          pending_count: 0,
+          failure_count: 0,
+          failure_descriptions: ''
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/learn_test/strategies/none_spec.rb
+++ b/spec/lib/learn_test/strategies/none_spec.rb
@@ -27,7 +27,7 @@ describe LearnTest::Strategies::None do
   describe '#run' do
     it 'prints a message' do
       strategy = LearnTest::Strategies::None.new(double(:runner, options: {}))
-      msg = "This directory doesn't appear to have any specs but a submission will be made.\n"
+      msg = "Your assignment was submitted. You can resubmit by running `learn test` again.\n"
 
       expect { strategy.run }.to output(msg).to_stdout
     end

--- a/spec/lib/learn_test/strategies/none_spec.rb
+++ b/spec/lib/learn_test/strategies/none_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+describe LearnTest::Strategies::None do
+  describe '#detect' do
+    context 'there is a .canvas file' do
+      before { FileUtils.touch('.canvas') }
+      after { FileUtils.rm('.canvas') }
+
+      it 'is true' do
+        runner = LearnTest::Runner.new(double(:repo), {})
+        strategy = LearnTest::Strategies::None.new(runner)
+
+        expect(strategy.detect).to eq(true)
+      end
+    end
+
+    context 'there is no .canvas file' do
+      it 'is false' do
+        runner = LearnTest::Runner.new(double(:repo), {})
+        strategy = LearnTest::Strategies::None.new(runner)
+
+        expect(strategy.detect).to eq(false)
+      end
+    end
+  end
+
+  describe '#run' do
+    it 'prints a message' do
+      strategy = LearnTest::Strategies::None.new(double(:runner, options: {}))
+      msg = "This directory doesn't appear to have any specs but a submission will be made.\n"
+
+      expect { strategy.run }.to output(msg).to_stdout
+    end
+  end
+
+  describe '#results' do
+    it 'contains the appropriate attributes' do
+      user_id = rand(1000..9999)
+      username = "test-username-#{user_id}"
+      oauth_token = "test-token-#{user_id}"
+      repo = double(:repo)
+
+      runner = LearnTest::Runner.new(repo, {})
+      strategy = LearnTest::Strategies::None.new(runner)
+
+      expect(LearnTest::UsernameParser).to receive(:get_username)
+        .and_return(username)
+
+      expect(LearnTest::UserIdParser).to receive(:get_user_id)
+        .and_return(user_id)
+
+      expect(LearnTest::LearnOauthTokenParser).to receive(:get_learn_oauth_token)
+        .and_return(oauth_token)
+
+
+      expect(strategy.results).to eq(
+        username: username,
+        github_user_id: user_id,
+        learn_oauth_token: oauth_token,
+        repo_name: repo,
+        build: {
+          test_suite: [{
+            framework: 'none',
+            formatted_output: '',
+            duration: nil
+          }]
+        },
+        examples: 0,
+        passing_count: 0,
+        pending_count: 0,
+        failure_count: 0,
+        failure_descriptions: ''
+      )
+    end
+  end
+end


### PR DESCRIPTION
For test runs within assignments from Canvas, ensure that a submission is made.