### PR TITLE
Add --exit to mocha multi install script

### DIFF
--- a/lib/learn_test/strategies/mocha.rb
+++ b/lib/learn_test/strategies/mocha.rb
@@ -71,7 +71,7 @@ module LearnTest
           'npm test'
         else
           install_mocha_multi
-          'node_modules/.bin/mocha -R mocha-multi --reporter-options spec=-,json=.results.json'
+          'node_modules/.bin/mocha -R mocha-multi --reporter-options spec=-,json=.results.json --exit'
         end
 
         system(command)


### PR DESCRIPTION
Fixes #78

Since Mocha v4.0.0 the --exit flag is needed to exit the test suite. 